### PR TITLE
Fix skill deletion bug

### DIFF
--- a/shared/utils/redis_client.py
+++ b/shared/utils/redis_client.py
@@ -297,6 +297,29 @@ class RedisClient:
         except RedisError as e:
             logger.error(f"Failed to get members of set {key}: {e}")
             return []
+
+    async def remove_from_set(self, key: str, *values: Any) -> int:
+        """Remove values from a set.
+
+        Args:
+            key: The set key.
+            *values: Values to remove (will be JSON-serialized if not strings).
+
+        Returns:
+            int: Number of values removed.
+        """
+        try:
+            serialized_values = []
+            for value in values:
+                if not isinstance(value, str):
+                    serialized_values.append(dumps(value))
+                else:
+                    serialized_values.append(value)
+
+            return await self.redis.srem(key, *serialized_values)
+        except (RedisError, TypeError) as e:
+            logger.error(f"Failed to remove values from set {key}: {e}")
+            return 0
     
     async def close(self) -> None:
         """Close the Redis connection."""

--- a/shared/utils/redis_skill_store.py
+++ b/shared/utils/redis_skill_store.py
@@ -154,7 +154,7 @@ class RedisSkillStore:
             await self.redis.delete_key(skill_key)
             
             # Remove from the set of all skills
-            await self.redis.delete_key(self.ALL_SKILLS_KEY)
+            await self.redis.remove_from_set(self.ALL_SKILLS_KEY, skill_id)
             
             logger.info(f"Deleted skill {skill_id}")
             return True


### PR DESCRIPTION
## Summary
- prevent redis skill set from being entirely removed when deleting a skill
- add a helper to remove items from a Redis set

## Testing
- `python -m py_compile shared/utils/redis_client.py shared/utils/redis_skill_store.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f481e95708327ac7aa14b08be9fea