### PR TITLE
Ensure reasoning sets current skill for execution

### DIFF
--- a/manual_test_agent.py
+++ b/manual_test_agent.py
@@ -29,7 +29,9 @@ async def create_agent():
                 "key_fact_extraction_enabled": True
             }
         },
-        "created_by": "test_user"
+        "created_by": "test_user",
+        "domain": "test",
+        "keywords": ["test"]
     }
     
     async with httpx.AsyncClient() as client:

--- a/services/agent_lifecycle/models/agent.py
+++ b/services/agent_lifecycle/models/agent.py
@@ -79,9 +79,11 @@ class Agent(BaseModel):
 # Request models for API
 class CreateAgentRequest(BaseModel):
     """Request model for creating a new agent."""
-    
+
     config: AgentConfig = Field(..., description="Agent configuration")
     created_by: Optional[str] = Field(default=None, description="User who created the agent")
+    domain: Optional[str] = Field(default=None, description="Domain name for delegation")
+    keywords: List[str] = Field(default_factory=list, description="Example keywords for this domain")
 
 
 class UpdateAgentStatusRequest(BaseModel):

--- a/services/agent_lifecycle/repository.py
+++ b/services/agent_lifecycle/repository.py
@@ -42,7 +42,12 @@ class AgentRepository:
         self.agent_store = self.redis_manager.agents
         logger.info("Agent repository initialized")
     
-    async def create_agent(self, agent: Agent) -> str:
+    async def create_agent(
+        self,
+        agent: Agent,
+        domain: Optional[str] = None,
+        keywords: Optional[List[str]] = None,
+    ) -> str:
         """Create a new agent.
         
         Args:
@@ -87,8 +92,26 @@ class AgentRepository:
             agent.updated_at = datetime.now()
             
             # Store the full agent data
-            await self.redis_manager.redis_client.set_value(agent_key, json.dumps(agent.dict(), cls=DateTimeEncoder))
-            
+            await self.redis_manager.redis_client.set_value(
+                agent_key,
+                json.dumps(agent.dict(), cls=DateTimeEncoder),
+            )
+
+            # Register delegation domain if provided and applicable
+            if domain and not agent.config.is_supervisor and agent.agent_id != "default-agent":
+                try:
+                    await self.redis_manager.delegation_store.register_domain(
+                        domain,
+                        agent.agent_id,
+                        keywords or [],
+                        agent.config.skills,
+                    )
+                    logger.info(
+                        f"Registered domain {domain} for agent {agent.agent_id}"
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to register domain {domain}: {e}")
+
             logger.info(f"Created agent {agent.agent_id}")
             return agent.agent_id
             

--- a/services/agent_lifecycle/router.py
+++ b/services/agent_lifecycle/router.py
@@ -73,8 +73,12 @@ async def create_agent(
             created_by=request.created_by
         )
         
-        # Store the agent
-        await repository.create_agent(agent)
+        # Store the agent and register domain if provided
+        await repository.create_agent(
+            agent,
+            domain=request.domain,
+            keywords=request.keywords,
+        )
         
         # Return the agent
         return AgentResponse(

--- a/services/agent_service/main.py
+++ b/services/agent_service/main.py
@@ -175,36 +175,9 @@ async def startup_event():
     existing_agents = await redis_manager.agent_store.list_agents()
 
     if not existing_agents:
-        # ----- Create Finance Agent -----
-        finance_config = AgentConfig(
-            agent_id="finance-agent",
-            persona=AgentPersona(
-                name="Finance Agent",
-                description="Provides stock information",
-                goals=["Answer finance questions"],
-                constraints=["Use the finance skill"],
-                tone="neutral",
-                system_prompt=(
-                    "You are a finance data specialist delegated by a supervisor agent. "
-                    "Provide the requested stock information concisely. Do not greet or "
-                    "mention that you are the Finance Agent or reveal details about the "
-                    "supervisor."
-                ),
-            ),
-            reasoning_model=ReasoningModel.LLAMA3_70B,
-            skills=["finance"],
-            memory=MemoryConfig(),
-            is_supervisor=False,
-        )
-
-        finance_agent = Agent(finance_config, memory_manager=memory_manager, skill_client=skill_client)
-        await finance_agent.initialize()
-        agent_registry["finance-agent"] = finance_agent
-        await redis_manager.delegation_store.register_domain("finance", "finance-agent", ["stock", "share", "ticker"], ["finance"])
-
         # ----- Create Default General Agent -----
         default_agent_id = "default-agent"
-        general_skill_ids = [s for s in skill_ids if s != "finance"]
+        general_skill_ids = skill_ids
 
         default_config = AgentConfig(
             agent_id=default_agent_id,
@@ -248,19 +221,17 @@ async def startup_event():
             is_supervisor=True,
         )
 
+        delegations = await _load_delegations()
         supervisor_agent = Agent(
             supervisor_config,
             memory_manager=memory_manager,
             skill_client=skill_client,
-            delegations={
-                "finance": {"agent": finance_agent},
-                "general": {"agent": general_agent},
-            },
+            delegations=delegations,
         )
         await supervisor_agent.initialize()
         agent_registry["supervisor-agent"] = supervisor_agent
 
-        logger.info("Created supervisor, finance, and general agents")
+        logger.info("Created supervisor and general agents")
     else:
         logger.info(f"Existing agents found: {existing_agents}. Loading agents")
         for agent_id in existing_agents:

--- a/services/agent_service/nodes/reasoning.py
+++ b/services/agent_service/nodes/reasoning.py
@@ -534,6 +534,17 @@ IMPORTANT JSON FORMATTING INSTRUCTIONS:
                 skill_to_use = None
             state.current_skill = None
         
+        # Update current_skill based on the reasoning outcome
+        if skill_to_use and not should_respond_directly:
+            state.current_skill = SkillExecution(
+                skill_id=skill_to_use.skill_id,
+                parameters=skill_to_use.parameters,
+                agent_id=state.agent_id,
+                conversation_id=state.conversation_id,
+            )
+        else:
+            state.current_skill = None
+
         # Update the agent state
         state.thought_process.append(thoughts)
         state.current_node = "reasoning"

--- a/tests/test_agent_domain_registration.py
+++ b/tests/test_agent_domain_registration.py
@@ -1,0 +1,62 @@
+import sys
+import types
+import asyncio
+import importlib
+from tests.helpers import FakeRedis
+
+# Patch redis modules
+fake_asyncio = types.ModuleType('redis.asyncio')
+fake_asyncio.Redis = FakeRedis
+sys.modules['redis.asyncio'] = fake_asyncio
+fake_exceptions = types.ModuleType('redis.exceptions')
+fake_exceptions.RedisError = Exception
+sys.modules['redis.exceptions'] = fake_exceptions
+fake_root = types.ModuleType('redis')
+fake_root.asyncio = fake_asyncio
+fake_root.exceptions = fake_exceptions
+fake_root.Redis = FakeRedis
+sys.modules['redis'] = fake_root
+
+import shared.utils.redis_client as redis_client
+importlib.reload(redis_client)
+from shared.utils.redis_manager import RedisManager
+
+from services.agent_lifecycle.repository import AgentRepository
+from services.agent_lifecycle.models.agent import (
+    Agent,
+    AgentStatus,
+    AgentConfig,
+    AgentPersona,
+    MemoryConfig,
+)
+from services.agent_lifecycle.models.agent import LLMConfig
+
+
+def test_create_agent_registers_domain():
+    manager = RedisManager(host='localhost', port=6379, db=0)
+    asyncio.run(manager.connect())
+    repo = AgentRepository(manager)
+    asyncio.run(repo.initialize())
+
+    config = AgentConfig(
+        agent_id='finance-agent',
+        persona=AgentPersona(
+            name='Fin',
+            description='Fin agent',
+            goals=[],
+            constraints=[],
+            tone='neutral',
+            system_prompt=''
+        ),
+        llm=LLMConfig(model_name='llama3-70b-8192'),
+        skills=['finance'],
+        memory=MemoryConfig(),
+        is_supervisor=False,
+    )
+
+    agent = Agent(agent_id='finance-agent', status=AgentStatus.INACTIVE, config=config)
+    asyncio.run(repo.create_agent(agent, domain='finance', keywords=['stock']))
+
+    mapping = asyncio.run(manager.delegation_store.get_domain('finance'))
+    assert mapping['agent_id'] == 'finance-agent'
+    assert 'stock' in mapping['keywords']


### PR DESCRIPTION
## Summary
- link selected skill from reasoning node to agent state
- register delegation domains when creating agents
- load delegations on startup without hard-coded finance agent
- accept domain info when creating agents
- add regression test for domain registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b0efc530832789623736a893f884